### PR TITLE
Remove arduino dependency

### DIFF
--- a/examples/forced_mode_idf/CMakeLists.txt
+++ b/examples/forced_mode_idf/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(forced_mode_idf)

--- a/examples/forced_mode_idf/platformio.ini
+++ b/examples/forced_mode_idf/platformio.ini
@@ -1,0 +1,20 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32@6.6.0
+board = esp32dev
+framework = espidf
+platform_packages =
+    platformio/framework-espidf@~3.50201.0
+lib_deps =
+    ../../
+    https://github.com/natanaeljr/esp32-I2Cbus
+monitor_speed = 115200

--- a/examples/forced_mode_idf/src/CMakeLists.txt
+++ b/examples/forced_mode_idf/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+# This file was automatically generated for projects
+# without default 'CMakeLists.txt' file.
+
+FILE(GLOB_RECURSE app_sources ${CMAKE_SOURCE_DIR}/src/*.*)
+
+idf_component_register(SRCS ${app_sources})

--- a/examples/forced_mode_idf/src/main.cpp
+++ b/examples/forced_mode_idf/src/main.cpp
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2021 Bosch Sensortec GmbH
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * 
+ */
+
+#include <stdio.h>
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "bme68xLibrary.h"
+#include "I2Cbus.hpp"
+
+#define BME688_ADD 0x77
+
+static const char* TAG = "main";
+
+Bme68x bme;
+
+int8_t read_bytes_wrapper(uint8_t a_register, uint8_t *data, uint32_t len, void *intfPtr) {
+  return static_cast<I2C_t *>(intfPtr)->readBytes(BME688_ADD, a_register, len, data)==ESP_OK  ? 0 : -1;
+}
+
+int8_t write_bytes_wrapper(uint8_t a_register, const uint8_t *data, uint32_t len,
+                                                    void *intfPtr) {
+  return static_cast<I2C_t *>(intfPtr)->writeBytes(BME688_ADD, a_register, len, data)==ESP_OK ? 0 : -1;
+}
+
+uint32_t IRAM_ATTR millis() { return (uint32_t) (esp_timer_get_time() / 1000ULL); }
+void IRAM_ATTR delay(uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
+uint32_t IRAM_ATTR micros() { return (uint32_t) esp_timer_get_time(); }
+
+void delay_microseconds_safe(uint32_t us) {  // avoids CPU locks that could trigger WDT or affect WiFi/BT stability
+  uint32_t start = micros();
+
+  const uint32_t lag = 5000;  // microseconds, specifies the maximum time for a CPU busy-loop.
+                              // it must be larger than the worst-case duration of a delay(1) call (hardware tasks)
+                              // 5ms is conservative, it could be reduced when exact BT/WiFi stack delays are known
+  if (us > lag) {
+    delay((us - lag) / 1000UL);  // note: in disabled-interrupt contexts delay() won't actually sleep
+    while (micros() - start < us - lag)
+      delay(1);  // in those cases, this loop allows to yield for BT/WiFi stack tasks
+  }
+  while (micros() - start < us)  // fine delay the remaining usecs
+    ;
+}
+
+void delay_us(uint32_t period, void *intfPtr) {
+  delay_microseconds_safe(period);
+}
+
+/**
+ * @brief Initializes the sensor and hardware settings
+ */
+void setup(void)
+{
+	i2c0.begin(GPIO_NUM_3,GPIO_NUM_0);
+	
+  /* initializes the sensor based on I2C library */
+	bme.begin(BME68X_I2C_INTF, read_bytes_wrapper, write_bytes_wrapper, delay_us, (void *) &i2c0);
+
+	if(bme.checkStatus())
+	{
+		if (bme.checkStatus() == BME68X_ERROR)
+		{
+			ESP_LOGI(TAG, "Sensor error: %d", bme.status);
+			return;
+		}
+		else if (bme.checkStatus() == BME68X_WARNING)
+		{
+			ESP_LOGI(TAG, "Sensor Warning: %d", bme.status);
+		}
+	}
+	
+	/* Set the default configuration for temperature, pressure and humidity */
+	bme.setTPH();
+
+	/* Set the heater configuration to 300 deg C for 100ms for Forced mode */
+	bme.setHeaterProf(300, 100);
+
+	ESP_LOGI(TAG, "TimeStamp(ms), Temperature(deg C), Pressure(Pa), Humidity(%%), Gas resistance(ohm), Status");
+}
+
+void loop(void)
+{
+	bme68xData data;
+
+	bme.setOpMode(BME68X_FORCED_MODE);
+	delay_microseconds_safe(bme.getMeasDur());
+
+	if (bme.fetchData())
+	{
+		bme.getData(data);
+		ESP_LOGI(TAG, "%lu, %f, %f, %f, %f, %d", millis(), data.temperature, data.pressure, data.humidity, data.gas_resistance, data.status);
+	}
+}
+
+void loop_task(void *pv_params) {
+  setup();
+  while (true) {
+    loop();
+  }
+}
+
+extern "C" void app_main()
+{
+	ESP_LOGI(TAG, "starting");
+	xTaskCreate(loop_task, "loopTask", 8192, nullptr, 1, NULL);
+}

--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+  "name": "BME68x Sensor library",
+  "description": "Bosch Sensortec BME680 and BME688 sensor library",
+  "homepage": "https://www.bosch-sensortec.com/software-tools/software/bme688-software/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/boschsensortec/Bosch-BME68x-Library"
+  },
+  "version": "1.2.40408",
+  "authors": {
+    "name": "Bosch Sensortec",
+    "email": "contact@bosch-sensortec.com"
+  },
+  "frameworks": "*",
+  "platforms": "*",
+  "build": {
+    "includeDir": "src/bme68x"
+  }
+}

--- a/src/bme68xLibrary.cpp
+++ b/src/bme68xLibrary.cpp
@@ -101,10 +101,12 @@
 
 Bme68x::Bme68x(void)
 {
+#ifdef ARDUINO
 	comm.i2c.wireobj = NULL;
 	comm.i2c.i2cAddr = 0;
 	comm.spi.spiobj = NULL;
 	comm.spi.cs = 0;
+#endif
 	status = BME68X_OK;
 	memset(&bme6, 0, sizeof(bme6));
 	memset(&conf, 0, sizeof(conf));
@@ -136,6 +138,7 @@ void Bme68x::begin(bme68xIntf intf, bme68x_read_fptr_t read, bme68x_write_fptr_t
 /**
  * @brief Function to initialize the sensor based on the Wire library
  */
+#ifdef ARDUINO
 void Bme68x::begin(uint8_t i2cAddr, TwoWire &i2c, bme68x_delay_us_fptr_t idleTask)
 {
 	comm.i2c.i2cAddr = i2cAddr;
@@ -172,6 +175,7 @@ void Bme68x::begin(uint8_t chipSelect, SPIClass &spi, bme68x_delay_us_fptr_t idl
 
 	status = bme68x_init(&bme6);
 }
+#endif
 
 /**
  * @brief Function to read a register
@@ -479,6 +483,7 @@ int8_t Bme68x::checkStatus(void)
 	}
 }
 
+#ifdef ARDUINO
 /**
  * @brief Function to get a brief text description of the error
  */
@@ -517,6 +522,7 @@ String Bme68x::statusString(void)
 
 	return ret;
 }
+
 
 /**
  * @brief Function that implements the default microsecond delay callback
@@ -664,3 +670,4 @@ int8_t bme68xI2cRead(uint8_t regAddr, uint8_t *regData, uint32_t length,
 
     return rslt;
 }
+#endif

--- a/src/bme68xLibrary.cpp
+++ b/src/bme68xLibrary.cpp
@@ -523,7 +523,7 @@ String Bme68x::statusString(void)
 	return ret;
 }
 
-
+#ifdef ARDUINO
 /**
  * @brief Function that implements the default microsecond delay callback
  */
@@ -531,6 +531,7 @@ void bme68xDelayUs(uint32_t periodUs, void *intfPtr) {
     (void) intfPtr;
     delayMicroseconds(periodUs);
 }
+#endif
 
 /**
  * @brief Function that implements the default SPI write transaction

--- a/src/bme68xLibrary.h
+++ b/src/bme68xLibrary.h
@@ -40,15 +40,19 @@
 #define BME68X_LIBRARY_H
 
 #include <string.h>
+
+#ifdef ARDUINO
 #include "Arduino.h"
 #include "Wire.h"
 #include "SPI.h"
+#endif
 
 #include "bme68x/bme68x.h"
 
 #define BME68X_ERROR            INT8_C(-1)
 #define BME68X_WARNING          INT8_C(1)
 
+#ifdef ARDUINO
 /**
  * Datatype working as an interface descriptor
  */
@@ -65,6 +69,7 @@ typedef union
         uint8_t cs;
     } spi;
 } bme68xScommT;
+#endif
 
 /** Datatype to keep consistent with camel casing */
 typedef struct bme68x_data          bme68xData;
@@ -73,6 +78,7 @@ typedef enum   bme68x_intf          bme68xIntf;
 typedef struct bme68x_conf          bme68xConf;
 typedef struct bme68x_heatr_conf    bme68xHeatrConf;
 
+#ifdef ARDUINO
 /**
  * @brief Function that implements the default microsecond delay callback
  * @param periodUs : Duration of the delay in microseconds
@@ -119,6 +125,7 @@ int8_t bme68xI2cWrite(uint8_t regAddr, const uint8_t *regData, uint32_t length, 
  * @return 0 if successful, non-zero otherwise
  */
 int8_t bme68xI2cRead(uint8_t regAddr, uint8_t *regData, uint32_t length, void *intfPtr);
+#endif
 
 class Bme68x
 {
@@ -141,7 +148,8 @@ public:
      */
     void begin(bme68xIntf intf, bme68x_read_fptr_t read, bme68x_write_fptr_t write,
             bme68x_delay_us_fptr_t idleTask, void *intfPtr);
-
+            
+#ifdef ARDUINO
     /**
      * @brief Function to initialize the sensor based on the Wire library
      * @param i2cAddr  : The I2C address the sensor is at
@@ -157,6 +165,7 @@ public:
      * @param idleTask   : Delay or Idle function
      */
     void begin(uint8_t chipSelect, SPIClass &spi, bme68x_delay_us_fptr_t idleTask = bme68xDelayUs);
+#endif
 
     /**
      * @brief Function to read a register
@@ -324,18 +333,21 @@ public:
      * @return -1 if an error occurred, 1 if warning occured else 0
      */
     int8_t checkStatus(void);
-
+#ifdef ARDUINO
     /**
      * @brief Function to get a brief text description of the error
      * @return Returns a string describing the error code
      */
     String statusString(void);
+#endif
 
 private:
     /** Datatype to keep consistent with camel casing
      * Datastructure to hold sensor settings
      */
+#ifdef ARDUINO
     bme68xScommT comm;
+#endif
     bme68xDev bme6;
     bme68xConf conf;
     bme68xHeatrConf heatrConf;


### PR DESCRIPTION
Remove Arduino dependency and add an example for platformio with espidf.
Without Arduino the I2C or SPI read and write functions need to be supplied and the StatusString cannot be used.
Tested with and without Arduino framework.

I plan to do the same for bsec2 library.