### PR TITLE
Add CMakeList.txt for ESP-IDF without Platformio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "src/bme68x/bme68x.c" "src/bme68xLibrary.cpp"
+    INCLUDE_DIRS "." "src" "src/bme68x"
+)


### PR DESCRIPTION
Add CMakeList.txt for use with ESP-IDF without PlatformIO.

Related to: 
- https://github.com/boschsensortec/Bosch-BSEC2-Library/issues/6
- https://github.com/boschsensortec/Bosch-BSEC2-Library/issues/47
